### PR TITLE
adding Syntax highlighting for the odin language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-highlight",
+ "tree-sitter-odin",
  "tree-sitter-rust",
  "tree-sitter-zig",
  "unicode-segmentation",
@@ -568,6 +569,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-odin"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24db210fe9ba2237c71c5030d7b146c7025420ba72dd8013d13cd822c3a8d77a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tree-sitter-rust = "0.24.2"
 tree-sitter-c = "0.24.2"
 tree-sitter-cpp = "0.23.4"
 tree-sitter-zig = "1.1.2"
+tree-sitter-odin = "1.3.0"
 
 # musl's default allocator is very slow with many threads because of mutex contention.
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -132,6 +132,14 @@ static ZIG_CONFIG: LazyLock<Option<HighlightConfiguration>> = LazyLock::new(|| {
         tree_sitter_zig::INJECTIONS_QUERY,
     )
 });
+static ODIN_CONFIG: LazyLock<Option<HighlightConfiguration>> = LazyLock::new(|| {
+    make_config(
+        tree_sitter_odin::LANGUAGE.into(),
+        "odin",
+        tree_sitter_odin::HIGHLIGHTS_QUERY,
+        tree_sitter_odin::INJECTIONS_QUERY,
+    )
+});
 
 fn make_config(
     language: Language,
@@ -152,6 +160,7 @@ fn config_for_path(path: &Path) -> Option<&'static HighlightConfiguration> {
         "c" => C_CONFIG.as_ref(),
         "cc" | "cpp" | "cxx" | "c++" | "h" | "hh" | "hpp" | "hxx" | "h++" => CPP_CONFIG.as_ref(),
         "zig" => ZIG_CONFIG.as_ref(),
+        "odin" => ODIN_CONFIG.as_ref(),
         _ => None,
     }
 }
@@ -162,6 +171,7 @@ fn config_for_injection(name: &str) -> Option<&'static HighlightConfiguration> {
         "c" => C_CONFIG.as_ref(),
         "cpp" | "c++" | "cc" | "cxx" => CPP_CONFIG.as_ref(),
         "zig" => ZIG_CONFIG.as_ref(),
+        "odin" => ODIN_CONFIG.as_ref(),
         _ => None,
     }
 }

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -356,6 +356,7 @@ mod tests {
             ("main.c", "int main(void) { return 1; }"),
             ("main.cpp", "class Thing { public: int value; };"),
             ("main.zig", "const x: i32 = 1;"),
+            ("main.odin", "package main\nmain :: proc() {}"),
         ] {
             let mut text = StyledText::default();
             text.chars.push_str(source);


### PR DESCRIPTION
just a little addition to support syntax highlighting for odin,
i literally just looked at the code that was there and copy pasted to fit odin  
<img width="768" height="555" alt="image" src="https://github.com/user-attachments/assets/b351b5a2-5a33-4d66-bc5d-9c6b5f29f079" />
