### PR TITLE
Support arbitrary addresses in disassembly tabs

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1311,11 +1311,79 @@ impl Debugger {
         Ok(())
     }
 
-    fn make_instruction_decoder<'a>(&self, range: Range<usize>, buf: &'a mut Vec<u8>) -> Result<iced_x86::Decoder<'a>> {
+    pub fn read_code_range(&self, range: Range<usize>) -> Result<(Range<usize>, Vec<u8>)> {
+        if range.len() > 100_000_000 { return err!(Sanity, "{} MB code range, suspiciously long", range.len() / 1_000_000); }
+        let map = match self.info.maps.addr_to_map(range.start) {
+            Some(x) => x,
+            None => return err!(ProcessState, "address not mapped: 0x{:x}", range.start),
+        };
+        let end = range.end.min(map.start.saturating_add(map.len));
+        if end <= range.start {
+            return err!(ProcessState, "empty memory range at 0x{:x}", range.start);
+        }
+
+        let range = range.start..end;
+        let mut buf = Vec::new();
+        self.read_code_range_into(range.clone(), &mut buf)?;
+
+        Ok((range, buf))
+    }
+
+    pub fn find_readable_code_range_around_addr(&self, addr: usize, before: usize, after: usize) -> Result<Range<usize>> {
+        let map = match self.info.maps.addr_to_map(addr) {
+            Some(x) => x,
+            None => return err!(ProcessState, "address not mapped: 0x{:x}", addr),
+        };
+        let map_end = map.start.saturating_add(map.len);
+        let start = addr.saturating_sub(before).max(map.start);
+        let end = addr.saturating_add(after).min(map_end);
+        if end <= start || addr >= end {
+            return err!(ProcessState, "empty memory range around 0x{:x}", addr);
+        }
+        if end - start > 100_000_000 { return err!(Sanity, "{} MB code range, suspiciously long", (end - start) / 1_000_000); }
+
+        let page_size = sysconf_PAGE_SIZE();
+        let required_page_start = (addr / page_size) * page_size;
+        let required_start = required_page_start.max(start);
+        let required_end = required_page_start.saturating_add(page_size).min(end);
+        let mut required = vec![0; required_end - required_start];
+        self.memory.read(required_start, &mut required)?;
+
+        let mut cur = required_start;
+        while cur > start {
+            let block_start = cur.saturating_sub(page_size).max(start);
+            let mut buf = vec![0; cur - block_start];
+            if self.memory.read(block_start, &mut buf).is_err() {
+                break;
+            }
+            cur = block_start;
+        }
+        let actual_start = cur;
+
+        cur = required_end;
+        while cur < end {
+            let block_end = cur.saturating_add(page_size).min(end);
+            let mut buf = vec![0; block_end - cur];
+            if self.memory.read(cur, &mut buf).is_err() {
+                break;
+            }
+            cur = block_end;
+        }
+        let actual_end = cur;
+
+        Ok(actual_start..actual_end)
+    }
+
+    fn read_code_range_into(&self, range: Range<usize>, buf: &mut Vec<u8>) -> Result<()> {
         if range.len() > 100_000_000 { return err!(Sanity, "{} MB code range, suspiciously long", range.len() / 1_000_000); }
         buf.resize(range.len(), 0);
         self.memory.read(range.start, buf)?;
 
+        self.fixup_code_range_bytes(range, buf);
+        Ok(())
+    }
+
+    fn fixup_code_range_bytes(&self, range: Range<usize>, buf: &mut [u8]) {
         // Fix up the INT3 breakpoint instructions. (We could read the code from the binary instead of memory to avoid
         // having to do this, but then stepping wouldn't work for code generated at runtime, not even single-instruction-step.)
         let mut i = self.breakpoint_locations.partition_point(|b| b.addr < range.start);
@@ -1326,6 +1394,10 @@ impl Debugger {
                 buf[b.addr - range.start] = b.original_byte;
             }
         }
+    }
+
+    fn make_instruction_decoder<'a>(&self, range: Range<usize>, buf: &'a mut Vec<u8>) -> Result<iced_x86::Decoder<'a>> {
+        self.read_code_range_into(range.clone(), buf)?;
         Ok(iced_x86::Decoder::with_ip(64, buf, range.start as u64, 0))
     }
 
@@ -2778,7 +2850,11 @@ impl Debugger {
         let step = self.stepping.as_mut().unwrap();
         let cfa = Self::get_cfa_for_step(&self.info, &self.symbols, &mut self.log, &self.memory, addr, regs);
         let cfa = match cfa {
-            None => return step.internal_kind == StepKind::Into,
+            None if step.internal_kind == StepKind::Into => {
+                step.stack_digest.clear();
+                return true;
+            }
+            None => return false,
             Some(c) => c };
         let (cfa_done, ranges_done) = match step.internal_kind {
             StepKind::Into => (cfa != step.cfa, !in_ranges),

--- a/src/disassembly.rs
+++ b/src/disassembly.rs
@@ -170,8 +170,16 @@ impl<'a> SymbolResolver for Resolver<'a> {
     }
 }
 
-pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Range<usize>>, symbols: Option<&Symbols>, code: Option<&[u8]>, intro: StyledText, palette: &Palette) -> Disassembly {
-    clean_up_ranges(&mut static_addr_ranges);
+pub fn disassemble_function(function_idx: usize, static_addr_ranges: Vec<Range<usize>>, symbols: &Symbols, intro: StyledText, palette: &Palette) -> Disassembly {
+    disassemble_addr_ranges(Some((function_idx, symbols)), static_addr_ranges, None, intro, palette)
+}
+
+pub fn disassemble_memory(range: Range<usize>, code: &[u8], intro: StyledText, palette: &Palette) -> Disassembly {
+    disassemble_addr_ranges(None, vec![range], Some(code), intro, palette)
+}
+
+fn disassemble_addr_ranges(function: Option<(usize, &Symbols)>, mut addr_ranges: Vec<Range<usize>>, memory_code: Option<&[u8]>, intro: StyledText, palette: &Palette) -> Disassembly {
+    clean_up_ranges(&mut addr_ranges);
 
     let mut res = Disassembly {text: intro, lines: Vec::new(), error: None, max_abs_relative_addr: 0, indent_width: str_width(&palette.tree_indent.0), widest_line: 0, symbols_shard: None};
     let mut subfunc_idxs: Vec<Range<usize>> = Vec::new();
@@ -182,22 +190,22 @@ pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Ran
         res.lines.push(DisassemblyLineInfo {kind: DisassemblyLineKind::Intro, static_addr: 0, ..Default::default()});
     }
 
-    if let Some(symbols) = &symbols {
+    if let Some((function_idx, symbols)) = function {
         let function = &symbols.functions[function_idx];
         res.symbols_shard = Some(function.shard_idx());
         subfunc_idxs = (1..function.num_levels()).map(|i| symbols.subfunction_idxs_at_level(i, function)).collect();
         subfunctions = &symbols.shards[function.shard_idx()].subfunctions;
     }
 
-    for (addr_range_idx, static_addr_range) in static_addr_ranges.iter().enumerate() {
+    for (addr_range_idx, static_addr_range) in addr_ranges.iter().enumerate() {
         if static_addr_range.len() > 100_000_000 {
             return res.with_error(error!(Sanity, "{} MB to disassemble, suspiciously much", static_addr_range.len() / 1_000_000), palette);
         }
 
-        let code: &[u8] = if let Some(code) = code.clone() {
-            assert_eq!(static_addr_ranges.len(), 1);
+        let code: &[u8] = if let Some(code) = memory_code {
+            assert_eq!(addr_ranges.len(), 1);
             code
-        } else if let Some(symbols) = &symbols {
+        } else if let Some((_, symbols)) = function {
             // Read the machine code from file rather than memory so that it doesn't show our breakpoint instructions.
             match symbols.elves[0].addr_range_to_offset_range(static_addr_range.start, static_addr_range.end) {
                 None => return res.with_error(error!(Dwarf, "function address range out of bounds of executable: {:x}-{:x}", static_addr_range.start, static_addr_range.end), palette),
@@ -213,7 +221,7 @@ pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Ran
             res.lines.push(DisassemblyLineInfo {kind: DisassemblyLineKind::Separator, static_addr: static_addr_range.start, ..Default::default()});
         }
 
-        let resolver = Resolver {symbols: symbols.clone(), current_function: static_addr_range.clone()};
+        let resolver = Resolver {symbols: function.map(|(_, symbols)| symbols), current_function: static_addr_range.clone()};
         // NasmFormatter wants to own the symbol resolver for some reason. (Probably it would be too inconvenient or inefficient to have lifetime argument all throughout the formatter implementation.)
         // We trust that the SymbolResolver reference isn't retained after the formatter is destroyed, so it should be ok to fudge the lifetime here.
         let resolver: Resolver<'static> = unsafe { std::mem::transmute(resolver) };
@@ -221,7 +229,7 @@ pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Ran
         let mut decoder = Decoder::with_ip(64, code, static_addr_range.start as u64, DecoderOptions::NONE);
         let mut formatter = NasmFormatter::with_options(Some(Box::new(resolver)), None);
 
-        let mut line_iter = if let Some(symbols) = &symbols {
+        let mut line_iter = if let Some((_, symbols)) = function {
             let mut line_iter = symbols.addr_to_line_iter(static_addr_range.start).peekable();
             line_iter.next_if(|line| line.addr() < static_addr_range.start);
             Some(line_iter)
@@ -244,7 +252,7 @@ pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Ran
             let mut cur_subfunction: Option<usize> = None;
             let mut is_statement = false;
 
-            if let &Some(symbols) = &symbols {
+            if let Some((function_idx, symbols)) = function {
                 let write_line_number = |line: LineInfo, kind: DisassemblyLineKind, res: &mut Disassembly, subfunction_level: u16, leaf_line: &mut Option<LineInfo>, subfunction: Option<usize>| {
                     let file = match line.file_idx() {
                         None => return,
@@ -340,6 +348,104 @@ pub fn disassemble_function(function_idx: usize, mut static_addr_ranges: Vec<Ran
     res.finish()
 }
 
+/// Finds a unique candidate instruction stream at or before `ip`.
+/// `ip` is assumed to be a real instruction pointer, so candidates are kept only
+/// if decoding from them reaches `ip` as an instruction start.
+///
+/// This probes candidate stream starts near `probe_start`, up to one maximum x86
+/// instruction length away. `probe_len` bounds the accepted probe window, but the
+/// caller is expected to advance `probe_start` when it wants to test later starts.
+pub fn find_unique_instruction_start_before_ip(code: &[u8], range_start: usize, probe_start: usize, probe_len: usize, ip: usize) -> Option<usize> {
+    let range_end = range_start.saturating_add(code.len());
+    if probe_start < range_start || probe_start >= range_end || ip < probe_start || ip >= range_end || probe_len == 0 {
+        return None;
+    }
+    let last_probe_start = probe_start.saturating_add(probe_len).min(range_end - 1);
+    let last_start = ip.min(last_probe_start);
+    if last_start < probe_start {
+        return None;
+    }
+
+    let mut found = None;
+    let initial_last_start = probe_start.saturating_add(MAX_X86_INSTRUCTION_BYTES - 1).min(last_start);
+    for start in probe_start..=initial_last_start {
+        let mut decoder = Decoder::with_ip(64, &code[start - range_start..], start as u64, DecoderOptions::NONE);
+        while decoder.can_decode() {
+            let instruction = decoder.decode();
+            if instruction.is_invalid() || instruction.len() == 0 {
+                break;
+            }
+            let instruction_start = instruction.ip() as usize;
+            if instruction_start == ip {
+                if found.is_some() {
+                    return None;
+                }
+                found = Some(start);
+                break;
+            }
+            if instruction_start > ip {
+                break;
+            }
+        }
+    }
+    found
+}
+
+pub fn find_best_instruction_start_before_addr(code: &[u8], range_start: usize, probe_start: usize, probe_len: usize, addr: usize, ip_anchor: Option<usize>) -> Option<usize> {
+    let range_end = range_start.saturating_add(code.len());
+    if probe_start < range_start || probe_start >= range_end || addr < probe_start || addr >= range_end {
+        return None;
+    }
+    let ip_anchor = ip_anchor.filter(|ip| range_start <= *ip && *ip < range_end);
+    if probe_len == 0 {
+        return None;
+    }
+    let last_probe_start = probe_start.saturating_add(probe_len).min(range_end - 1);
+
+    let first_start = addr.saturating_sub(MAX_X86_INSTRUCTION_BYTES - 1).max(probe_start);
+    let last_start = addr.min(last_probe_start);
+    if first_start > last_start {
+        return None;
+    }
+    let mut best: Option<(usize, usize)> = None; // (decoded_until, instruction_start)
+
+    for start in first_start..=last_start {
+        let mut decoder = Decoder::with_ip(64, &code[start - range_start..], start as u64, DecoderOptions::NONE);
+        let instruction = decoder.decode();
+        if instruction.is_invalid() || instruction.len() == 0 {
+            continue;
+        }
+        let instruction_start = instruction.ip() as usize;
+        let instruction_end = instruction_start.saturating_add(instruction.len());
+        if instruction_start <= addr && addr < instruction_end {
+            let mut decoded_until = instruction_end;
+            let mut saw_ip_anchor = ip_anchor.map_or(true, |ip| instruction_start == ip);
+            while decoder.can_decode() && decoded_until < range_end {
+                let instruction = decoder.decode();
+                if instruction.is_invalid() || instruction.len() == 0 {
+                    break;
+                }
+                if ip_anchor == Some(instruction.ip() as usize) {
+                    saw_ip_anchor = true;
+                }
+                decoded_until = instruction.ip().saturating_add(instruction.len() as u64) as usize;
+            }
+            // If we know nearby RIP, use it as a hard instruction-boundary anchor: real execution
+            // can only stop at instruction starts, which disambiguates many valid-but-wrong x86 decodes.
+            if !saw_ip_anchor {
+                continue;
+            }
+
+            // Prefer the stream that remains valid the longest; if alternatives converge equally far,
+            // use the earliest start so manual `g` can recover from landing inside a real instruction.
+            if best.map_or(true, |(best_until, best_start)| decoded_until > best_until || decoded_until == best_until && instruction_start < best_start) {
+                best = Some((decoded_until, instruction_start));
+            }
+        }
+    }
+    best.map(|(_, instruction_start)| instruction_start)
+}
+
 fn clean_up_ranges(ranges: &mut Vec<Range<usize>>) {
     if ranges.is_empty() {
         return;
@@ -359,4 +465,278 @@ fn clean_up_ranges(ranges: &mut Vec<Range<usize>>) {
         }
     }
     ranges.truncate(j+1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: usize = 0x1000;
+
+    struct UniqueStartCase {
+        name: &'static str,
+        code: &'static [u8],
+        range_start: usize,
+        probe_start: usize,
+        probe_len: usize,
+        ip: usize,
+        expected: Option<usize>,
+    }
+
+    struct BestStartCase {
+        name: &'static str,
+        code: &'static [u8],
+        range_start: usize,
+        probe_start: usize,
+        probe_len: usize,
+        addr: usize,
+        ip_anchor: Option<usize>,
+        expected: Option<usize>,
+    }
+
+    const UNIQUE_RET: &[u8] = &[0x0f, 0x0f, 0x0f, 0x0f, 0xc3];
+    const LONG_NOP_THEN_RET: &[u8] = &[
+        // 14 operand-size prefixes + nop: every suffix ending at 0x90 is also a viable instruction.
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+        0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x90,
+        0xc3,
+    ];
+    const JIT_HELLO_PREFIX: &[u8] = &[
+        0xb8, 0x01, 0x00, 0x00, 0x00,             // mov eax, 1
+        0xbf, 0x01, 0x00, 0x00, 0x00,             // mov edi, 1
+        0x48, 0x8d, 0x35, 0x08, 0x00, 0x00, 0x00, // lea rsi, [rip+8]
+        0xba, 0x0c, 0x00, 0x00, 0x00,             // mov edx, 12
+        0x0f, 0x05,                               // syscall
+        0xc3,                                     // ret
+    ];
+
+    #[test]
+    fn find_unique_instruction_start_before_ip_cases() {
+        let cases = [
+            UniqueStartCase {
+                name: "address_at_probe_start",
+                code: JIT_HELLO_PREFIX,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: JIT_HELLO_PREFIX.len(),
+                ip: BASE,
+                expected: Some(BASE),
+            },
+            UniqueStartCase {
+                name: "unique_anchored_stream",
+                code: &[
+                    0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f,
+                    0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f, 0x0f,
+                    0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3, 0xc3,
+                ],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 21,
+                ip: BASE + 20,
+                expected: Some(BASE + 14),
+            },
+            UniqueStartCase {
+                name: "does_not_scan_whole_probe_window",
+                code: &[
+                    0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
+                    0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc,
+                    0x0f, 0x05, 0xc3,
+                ],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 19,
+                ip: BASE + 18,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "single_byte_instruction_stream_is_ambiguous",
+                code: &[0x90, 0x90, 0x90, 0x90, 0xc3],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 5,
+                ip: BASE + 4,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "prefix_chain_is_ambiguous",
+                code: LONG_NOP_THEN_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: LONG_NOP_THEN_RET.len(),
+                ip: BASE + 15,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "anchor_filters_unanchored_candidate",
+                code: &[0x0f, 0x1f, 0x40, 0x00, 0xc3],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 5,
+                ip: BASE + 4,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "multiple_anchored_candidates_are_ambiguous",
+                code: &[0x90, 0x0f, 0x05, 0xc3],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 4,
+                ip: BASE + 3,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "probe_before_range",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE - 1,
+                probe_len: UNIQUE_RET.len(),
+                ip: BASE + 4,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "probe_after_range",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE + UNIQUE_RET.len(),
+                probe_len: 1,
+                ip: BASE + 4,
+                expected: None,
+            },
+            UniqueStartCase {
+                name: "zero_len_probe",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 0,
+                ip: BASE + 4,
+                expected: None,
+            },
+        ];
+
+        for case in cases {
+            let found = find_unique_instruction_start_before_ip(case.code, case.range_start, case.probe_start, case.probe_len, case.ip);
+            assert_eq!(case.expected, found, "{}", case.name);
+        }
+    }
+
+    #[test]
+    fn find_best_instruction_start_before_addr_cases() {
+        let cases = [
+            BestStartCase {
+                name: "address_inside_instruction",
+                code: &[0x0f, 0x05],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 1,
+                addr: BASE + 1,
+                ip_anchor: None,
+                expected: Some(BASE),
+            },
+            BestStartCase {
+                name: "jit_mov_eax_one_prefers_real_stream_without_anchor",
+                code: JIT_HELLO_PREFIX,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: JIT_HELLO_PREFIX.len(),
+                addr: BASE + 1,
+                ip_anchor: None,
+                expected: Some(BASE),
+            },
+            BestStartCase {
+                name: "jit_mov_eax_one_uses_ip_anchor",
+                code: JIT_HELLO_PREFIX,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: JIT_HELLO_PREFIX.len(),
+                addr: BASE + 1,
+                ip_anchor: Some(BASE),
+                expected: Some(BASE),
+            },
+            BestStartCase {
+                name: "jit_mov_eax_one_rejects_wrong_ip_anchor",
+                code: JIT_HELLO_PREFIX,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: JIT_HELLO_PREFIX.len(),
+                addr: BASE + 1,
+                ip_anchor: Some(BASE + 1),
+                expected: Some(BASE + 1),
+            },
+            BestStartCase {
+                name: "anchor_before_candidate_window_rejects_all_candidates",
+                code: &[0x90, 0x90, 0x0f, 0x05],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 4,
+                addr: BASE + 3,
+                ip_anchor: Some(BASE),
+                expected: None,
+            },
+            BestStartCase {
+                name: "address_at_instruction_start",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: UNIQUE_RET.len(),
+                addr: BASE + 4,
+                ip_anchor: None,
+                expected: Some(BASE + 4),
+            },
+            BestStartCase {
+                name: "address_in_following_instruction",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: UNIQUE_RET.len(),
+                addr: BASE + 4,
+                ip_anchor: None,
+                expected: Some(BASE + 4),
+            },
+            BestStartCase {
+                name: "single_byte_stream_chooses_only_containing_start",
+                code: &[0x90, 0x90, 0x90, 0x90, 0xc3],
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: 5,
+                addr: BASE + 2,
+                ip_anchor: None,
+                expected: Some(BASE + 2),
+            },
+            BestStartCase {
+                name: "prefix_chain_tie_chooses_earliest_start",
+                code: LONG_NOP_THEN_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: LONG_NOP_THEN_RET.len(),
+                addr: BASE + 14,
+                ip_anchor: None,
+                expected: Some(BASE),
+            },
+            BestStartCase {
+                name: "prefix_chain_ret_chooses_ret",
+                code: LONG_NOP_THEN_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: LONG_NOP_THEN_RET.len(),
+                addr: BASE + 15,
+                ip_anchor: None,
+                expected: Some(BASE + 15),
+            },
+            BestStartCase {
+                name: "address_after_stream",
+                code: UNIQUE_RET,
+                range_start: BASE,
+                probe_start: BASE,
+                probe_len: UNIQUE_RET.len(),
+                addr: BASE + UNIQUE_RET.len(),
+                ip_anchor: None,
+                expected: None,
+            },
+        ];
+
+        for case in cases {
+            let found = find_best_instruction_start_before_addr(case.code, case.range_start, case.probe_start, case.probe_len, case.addr, case.ip_anchor);
+            assert_eq!(case.expected, found, "{}", case.name);
+        }
+    }
 }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -246,7 +246,8 @@ Debugging tips:
  * No whole-file breakpoints, signal breakpoints (except for always-on stop on fatal signals).
  * Conditional breakpoints are not super fast: a few thousand evaluations per second.
  * Inside libraries that were dlopen()ed at runtime, breakpoints get disabled on program restart. Manually disable-enable the breakpoint after the dlopen() to reactivate it.
- * The 'disassembly' window can only open functions that appear in .symtab or debug info. Can't disassemble arbitrary memory, e.g. JIT-generated code or code from binaries without .symtab or debug info.
+ * The 'disassembly' window prefers functions from .symtab or debug info, but can fall back to memory disassembly. Press 'g' and enter a single raw address to open memory around that address if no function is found; unresolved stack-frame IPs can also open memory tabs automatically.
+    Explicit address ranges are not supported yet.
  * The debugger gets noticeably slow when the program has > 1K threads, and unusably slow with 20K threads. Part of it is inevitable syscalls
    (to start/stop all n threads we have to do n*const syscalls, then wait for n notifications - that takes a while), but there's a lot of room for improvement anyway
    (reduce the const, do the syscalls in parallel, avoid the remaining O(n^2) work on our side).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -48,7 +48,7 @@ pub struct UIState {
     // when symbols are loaded, we want to try again and stop showing errors; but maybe the user already opened some non-error file and is looking at it - then we shouldn't forcefully switch to current file;
     // so we set this flag, which tells the windows to scroll only if the error tab is selected.
     should_scroll_source: Option<(Option<SourceScrollTarget>, /*only_if_on_error_tab*/ bool)>,
-    should_scroll_disassembly: Option<(Result<DisassemblyScrollTarget>, /*only_if_on_error_tab*/ bool)>,
+    should_scroll_disassembly: Option<(Result<DisassemblyOpenRequest>, /*only_if_on_error_tab*/ bool)>,
     should_edit_breakpoint_condition: Option<BreakpointId>,
 }
 
@@ -78,12 +78,50 @@ struct SourceScrollTarget {
     cascade: bool, // scroll disassembly as well
 }
 
-struct DisassemblyScrollTarget {
-    binary_id: usize,
-    function_idx: usize,
-    static_pseudo_addr: usize,
-    subfunction_level: u16,
-    cascade: bool, // scroll source as well
+enum DisassemblyOpenRequest {
+    Function {
+        binary_id: usize,
+        function_idx: usize,
+        static_pseudo_addr: usize,
+        subfunction_level: u16,
+        cascade: bool, // scroll source as well
+    },
+    Memory {
+        range: Range<usize>,
+        requested_addr: usize,
+        scroll_addr: usize,
+        ip_anchor: Option<usize>,
+        cascade: bool,
+    },
+    AutoMemory {
+        ip: usize,
+        cascade: bool,
+    },
+}
+enum DisassemblyScrollTarget {
+    Function {
+        static_pseudo_addr: usize,
+        subfunction_level: u16,
+    },
+    Memory {
+        addr: usize,
+    },
+}
+
+impl DisassemblyOpenRequest {
+    fn cascade(&self) -> bool {
+        match self {
+            Self::Function {cascade, ..} | Self::Memory {cascade, ..} | Self::AutoMemory {cascade, ..} => *cascade,
+        }
+    }
+
+    fn scroll_target(&self) -> DisassemblyScrollTarget {
+        match self {
+            Self::Function {static_pseudo_addr, subfunction_level, ..} => DisassemblyScrollTarget::Function {static_pseudo_addr: *static_pseudo_addr, subfunction_level: *subfunction_level},
+            Self::Memory {scroll_addr, ..} => DisassemblyScrollTarget::Memory {addr: *scroll_addr},
+            Self::AutoMemory {ip, ..} => DisassemblyScrollTarget::Memory {addr: *ip},
+        }
+    }
 }
 
 pub trait WindowContent {
@@ -1196,7 +1234,7 @@ impl WatchesWindow {
                 ui.should_redraw = true;
             }
             &ValueClickAction::Function {binary_id, function_idx, static_addr} => {
-                let target = DisassemblyScrollTarget {binary_id, function_idx, static_pseudo_addr: static_addr, subfunction_level: 0, cascade: true};
+                let target = DisassemblyOpenRequest::Function {binary_id, function_idx, static_pseudo_addr: static_addr, subfunction_level: 0, cascade: true};
                 state.should_scroll_disassembly = Some((Ok(target), /*only_if_on_error_tab*/ false));
                 ui.should_redraw = true;
             }
@@ -1838,11 +1876,13 @@ struct DisassemblyTab {
     ephemeral: bool,
 
     // Cases:
-    //  * locator is None, error is Some - couldn't find function for current address; this is a tab for the error message about that,
-    //  * locator is Some, error is Some - couldn't find function, but may try again later (after drop_caches()),
-    //  * locator is Some, error is None, cached_function_idx is None - didn't try finding the function yet (loaded from save file) or the Symbols was deloaded,
-    //  * locator is Some, error is None, cached_function_idx is Some - found the function is Symbols.
+    //  * locator is Some, memory_range is None - function tab; cached_function_idx is filled when the function is found in current Symbols,
+    //  * locator is None, memory_range is Some - memory tab backed by a runtime address range,
+    //  * locator is Some, error is Some - function tab whose locator couldn't currently be resolved,
+    //  * locator is None, memory_range is None, error is Some - generic error tab.
     locator: Option<FunctionLocator>,
+    memory_range: Option<Range<usize>>,
+    requested_addr: usize,
     error: Option<Error>,
     cached_function_idx: Option<(/*binary_id*/ usize, /*function_idx*/ usize)>,
 
@@ -1854,21 +1894,28 @@ struct DisassemblyTab {
     area_state: AreaState,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum DisassemblyCacheKey {
+    Function(/*binary_id*/ usize, /*function_idx*/ usize),
+    Memory(/*start*/ usize, /*end*/ usize, /*requested_addr*/ usize),
+}
+
 struct DisassemblyWindow {
     tabs: Vec<DisassemblyTab>,
-    cache: HashMap<(/*binary_id*/ usize, /*function_idx*/ usize), Disassembly>,
+    cache: HashMap<DisassemblyCacheKey, Disassembly>,
     tabs_state: TabsState,
     search_dialog: Option<SearchDialog>,
     go_to_address_bar: SearchBar,
     go_to_address_error: Option<Error>,
     source_scrolled_to: Option<(/*binary_id*/ usize, /*function_idx*/ usize, /*disas_line*/ usize, /*selected_subfunction_level*/ u16)>,
+    failed_memory_ranges: Vec<Range<usize>>,
 }
 
-impl Default for DisassemblyWindow { fn default() -> Self { Self {tabs: Vec::new(), cache: HashMap::new(), tabs_state: TabsState::default(), search_dialog: None, go_to_address_bar: SearchBar::default(), go_to_address_error: None, source_scrolled_to: None} } }
+impl Default for DisassemblyWindow { fn default() -> Self { Self {tabs: Vec::new(), cache: HashMap::new(), tabs_state: TabsState::default(), search_dialog: None, go_to_address_bar: SearchBar::default(), go_to_address_error: None, source_scrolled_to: None, failed_memory_ranges: Vec::new()} } }
 
 impl DisassemblyWindow {
-    fn open_function(&mut self, target: Result<DisassemblyScrollTarget>, debugger: &Debugger) -> Result<()> {
-        let target = match target {
+    fn open_disassembly(&mut self, request: Result<DisassemblyOpenRequest>, debugger: &Debugger) -> Result<()> {
+        let request = match request {
             Ok(x) => x,
             // Ignore requests to open a "symbols are loading" error tab, because such tab would remain after symbols are loaded, and it'd be confusing.
             Err(e) if e.is_loading() => return Ok(()),
@@ -1878,33 +1925,178 @@ impl DisassemblyWindow {
                 return Ok(());
             }
         };
+        let (target_binary_id, target_function_idx) = match request {
+            DisassemblyOpenRequest::Function {binary_id, function_idx, ..} => (binary_id, function_idx),
+            DisassemblyOpenRequest::Memory {range, requested_addr, ip_anchor, ..} => {
+                for i in 0..self.tabs.len() {
+                    let tab_requested_addr = self.tabs[i].requested_addr;
+                    if self.tabs[i].memory_range.as_ref() == Some(&range) && tab_requested_addr == requested_addr {
+                        if let Some(ip) = ip_anchor.filter(|ip| range.start <= *ip && *ip < range.end) {
+                            if Self::cached_memory_disassembly_has_instruction_start(&self.cache, &range, tab_requested_addr, ip) == Some(false) {
+                                self.cache.remove(&DisassemblyCacheKey::Memory(range.start, range.end, tab_requested_addr));
+                            }
+                        }
+                        self.tabs_state.select(i);
+                        return Ok(());
+                    }
+                }
+                self.tabs.push(DisassemblyTab {
+                    identity: random(), memory_range: Some(range.clone()), requested_addr,
+                    title: format!("mem:{:x}", requested_addr), ephemeral: true,
+                    ..Default::default()
+                });
+                self.tabs_state.select(self.tabs.len() - 1);
+                return Ok(());
+            }
+            DisassemblyOpenRequest::AutoMemory {ip, ..} => {
+                if let Err(e) = self.open_auto_memory(ip, debugger) {
+                    self.tabs.push(DisassemblyTab {identity: random(), error: Some(e), title: "[memory]".to_string(), ephemeral: true, ..Default::default()});
+                    self.tabs_state.select(self.tabs.len() - 1);
+                }
+                return Ok(());
+            }
+        };
         for i in 0..self.tabs.len() {
             if let Some((binary, function_idx)) = self.resolve_function_for_tab(i, debugger) {
-                if binary.id == target.binary_id && function_idx == target.function_idx {
+                if binary.id == target_binary_id && function_idx == target_function_idx {
                     self.tabs_state.select(i);
                     return Ok(());
                 }
             }
         }
 
-        let binary = match debugger.symbols.get(target.binary_id) {
+        let binary = match debugger.symbols.get(target_binary_id) {
             Some(x) => x,
             // The binary may have been evicted after `target` was produced, e.g. if the debuggee re-execed, or a stale result was selected in the find-function dialog.
             None => return err!(NoFunction, "binary was unloaded"),
         };
         let symbols = binary.symbols.as_ref_clone_error()?;
-        let function = &symbols.functions[target.function_idx];
+        let function = &symbols.functions[target_function_idx];
         let demangled_name = function.demangle_name();
         let title = Self::make_title(&demangled_name);
         self.tabs.push(DisassemblyTab {
             identity: random(), locator: Some(FunctionLocator {binary_locator: binary.locator.clone(), mangled_name: function.mangled_name().to_owned(), addr: function.addr, demangled_name}),
-            cached_function_idx: Some((target.binary_id, target.function_idx)), title, ephemeral: true, selected_subfunction_level: SUBFUNCTION_LEVEL_MAX, ..Default::default()});
+            cached_function_idx: Some((target_binary_id, target_function_idx)), title, ephemeral: true, selected_subfunction_level: SUBFUNCTION_LEVEL_MAX, ..Default::default()});
         self.tabs_state.select(self.tabs.len() - 1);
 
         Ok(())
     }
 
-    fn find_address(&self, mut query: &str, debugger: &Debugger) -> Result<DisassemblyScrollTarget> {
+    fn failed_memory_range_contains(&self, addr: usize) -> bool {
+        let i = self.failed_memory_ranges.partition_point(|r| r.end <= addr);
+        i < self.failed_memory_ranges.len() && self.failed_memory_ranges[i].start <= addr
+    }
+
+    fn remember_failed_memory_range(&mut self, mut range: Range<usize>) {
+        if range.is_empty() {
+            return;
+        }
+        let i = self.failed_memory_ranges.partition_point(|r| r.end < range.start);
+        while i < self.failed_memory_ranges.len() && self.failed_memory_ranges[i].start <= range.end {
+            let old = self.failed_memory_ranges.remove(i);
+            range.start = range.start.min(old.start);
+            range.end = range.end.max(old.end);
+        }
+        self.failed_memory_ranges.insert(i, range);
+        if self.failed_memory_ranges.len() > 1000 {
+            self.failed_memory_ranges.drain(0..500);
+        }
+    }
+
+    fn cached_memory_disassembly_has_instruction_start(cache: &HashMap<DisassemblyCacheKey, Disassembly>, range: &Range<usize>, requested_addr: usize, ip: usize) -> Option<bool> {
+        if !(range.start <= ip && ip < range.end) {
+            return Some(true);
+        }
+        cache.get(&DisassemblyCacheKey::Memory(range.start, range.end, requested_addr)).map(|disas| disas.static_addr_to_line(ip).is_some())
+    }
+
+    fn open_auto_memory(&mut self, ip: usize, debugger: &Debugger) -> Result<()> {
+        const AUTO_MEMORY_DISASSEMBLY_BEFORE: usize = 16 * 1024;
+        const AUTO_MEMORY_DISASSEMBLY_AFTER: usize = 16 * 1024;
+        const AUTO_MEMORY_ALIGNMENT_PROBE_LEN: usize = 1024;
+        const AUTO_MEMORY_ALIGNMENT_STEP: usize = 4 * 1024;
+
+        for i in 0..self.tabs.len() {
+            if let Some(range) = self.tabs[i].memory_range.clone().filter(|r| r.start <= ip && ip < r.end) {
+                let requested_addr = self.tabs[i].requested_addr;
+                match Self::cached_memory_disassembly_has_instruction_start(&self.cache, &range, requested_addr, ip) {
+                    Some(true) => {
+                        self.tabs_state.select(i);
+                        return Ok(());
+                    }
+                    Some(false) => { self.cache.remove(&DisassemblyCacheKey::Memory(range.start, range.end, requested_addr)); }
+                    None => {
+                        self.tabs_state.select(i);
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        if self.failed_memory_range_contains(ip) {
+            return err!(ProcessState, "memory disassembly previously failed around 0x{:x}", ip);
+        }
+
+        let requested_range = ip.saturating_sub(AUTO_MEMORY_DISASSEMBLY_BEFORE)..ip.saturating_add(AUTO_MEMORY_DISASSEMBLY_AFTER);
+        let mut range = match debugger.find_readable_code_range_around_addr(ip, AUTO_MEMORY_DISASSEMBLY_BEFORE, AUTO_MEMORY_DISASSEMBLY_AFTER) {
+            Ok(x) => x,
+            Err(e) => {
+                self.remember_failed_memory_range(requested_range);
+                return Err(e);
+            }
+        };
+        if !(range.start <= ip && ip < range.end) {
+            self.remember_failed_memory_range(range);
+            return err!(ProcessState, "memory read did not cover instruction pointer 0x{:x}", ip);
+        }
+        let (_, code) = match debugger.read_code_range(range.clone()) {
+            Ok(x) => x,
+            Err(e) => {
+                self.remember_failed_memory_range(range);
+                return Err(e);
+            }
+        };
+
+        let mut chosen_start = ip;
+        let mut probe_start = range.start;
+        while probe_start < ip {
+            if let Some(boundary) = find_unique_instruction_start_before_ip(&code, range.start, probe_start, AUTO_MEMORY_ALIGNMENT_PROBE_LEN, ip) {
+                chosen_start = boundary;
+                break;
+            }
+            probe_start = probe_start.saturating_add(AUTO_MEMORY_ALIGNMENT_STEP);
+        }
+
+        if chosen_start > range.start {
+            range.start = chosen_start;
+        }
+
+        self.tabs.push(DisassemblyTab {
+            identity: random(), memory_range: Some(range.clone()), requested_addr: ip,
+            title: format!("mem:{:x}", ip), ephemeral: true,
+            ..Default::default()
+        });
+        self.tabs_state.select(self.tabs.len() - 1);
+        Ok(())
+    }
+
+    fn find_manual_memory_target(addr: usize, debugger: &Debugger, ip_anchor: Option<usize>) -> Result<DisassemblyOpenRequest> {
+        const MANUAL_MEMORY_DISASSEMBLY_BEFORE: usize = 1024;
+        const MANUAL_MEMORY_DISASSEMBLY_AFTER: usize = 64 * 1024;
+        const MANUAL_MEMORY_ALIGNMENT_PROBE_LEN: usize = 1024;
+
+        let mut range = debugger.find_readable_code_range_around_addr(addr, MANUAL_MEMORY_DISASSEMBLY_BEFORE, MANUAL_MEMORY_DISASSEMBLY_AFTER)?;
+        let (_, code) = debugger.read_code_range(range.clone())?;
+        let probe_start = addr.saturating_sub(MANUAL_MEMORY_DISASSEMBLY_BEFORE).max(range.start);
+        let first_candidate_start = addr.saturating_sub(MAX_X86_INSTRUCTION_BYTES - 1).max(probe_start);
+        let ip_anchor = ip_anchor.filter(|ip| first_candidate_start <= *ip && *ip < range.end);
+        let chosen_start = find_best_instruction_start_before_addr(&code, range.start, probe_start, MANUAL_MEMORY_ALIGNMENT_PROBE_LEN, addr, ip_anchor).unwrap_or(addr);
+        if chosen_start > range.start {
+            range.start = chosen_start;
+        }
+        Ok(DisassemblyOpenRequest::Memory {range, requested_addr: addr, scroll_addr: addr, ip_anchor, cascade: true})
+    }
+
+    fn find_address(&self, mut query: &str, state: &UIState, debugger: &Debugger) -> Result<DisassemblyOpenRequest> {
         let relative = query.starts_with("+");
         if relative {
             query = &query[1..];
@@ -1927,8 +2119,9 @@ impl DisassemblyWindow {
                 Some(x) => x,
                 None => return err!(Usage, "no open function"),
             };
-            Ok(DisassemblyScrollTarget {binary_id, function_idx, static_pseudo_addr: function_locator.addr.0.saturating_add(addr), subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true})
+            Ok(DisassemblyOpenRequest::Function {binary_id, function_idx, static_pseudo_addr: function_locator.addr.0.saturating_add(addr), subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true})
         } else {
+            let function_target = (|| -> Result<DisassemblyOpenRequest> {
             let (static_addr, binary) = match debugger.addr_to_binary(addr) {
                 Ok((_, static_addr, binary, _)) => (static_addr, binary),
                 Err(err) => {
@@ -1953,8 +2146,20 @@ impl DisassemblyWindow {
                 }
             };
             let symbols = binary.symbols.as_ref_clone_error()?;
-            let (function, function_idx) = symbols.addr_to_function(static_addr)?;
-            Ok(DisassemblyScrollTarget {binary_id: binary.id, function_idx, static_pseudo_addr: static_addr, subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true})
+            let (_, function_idx) = symbols.addr_to_function(static_addr)?;
+            Ok(DisassemblyOpenRequest::Function {binary_id: binary.id, function_idx, static_pseudo_addr: static_addr, subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true})
+            })();
+            match function_target {
+                Ok(target) => Ok(target),
+                Err(function_err) if function_err.is_loading() => Err(function_err),
+                Err(function_err) => {
+                    let ip_anchor = debugger.threads.get(&state.selected_thread).and_then(|thread| thread.info.regs.get_option(RegisterIdx::Rip)).map(|(ip, _)| ip as usize);
+                    match Self::find_manual_memory_target(addr, debugger, ip_anchor) {
+                        Ok(target) => Ok(target),
+                        Err(memory_err) => Err(if function_err.is_no_function() || function_err.is_missing_symbols() {memory_err} else {function_err}),
+                    }
+                }
+            }
         }
     }
 
@@ -2040,15 +2245,49 @@ impl DisassemblyWindow {
         Some((binary, function_idx))
     }
 
-    fn find_or_disassemble_function<'a>(cache: &'a mut HashMap<(usize, usize), Disassembly>, binary: &Binary, function_idx: usize, palette: &Palette) -> &'a Disassembly {
+    fn find_or_disassemble_function<'a>(cache: &'a mut HashMap<DisassemblyCacheKey, Disassembly>, binary: &Binary, function_idx: usize, palette: &Palette) -> &'a Disassembly {
         let indent_width = str_width(&palette.tree_indent.0);
-        let e = cache.entry((binary.id, function_idx));
+        let e = cache.entry(DisassemblyCacheKey::Function(binary.id, function_idx));
         match e {
             Entry::Occupied(o) if o.get().indent_width == indent_width => o.into_mut(),
             _ => {
                 // Would be nice to also support disassembling arbitrary memory, regardless of functions or binaries. E.g. for JIT-generated code.
                 let d = match Self::disassemble_function(binary, function_idx, palette) {
                     Ok(d) => d,
+                    Err(e) => Disassembly::new().with_error(e, palette),
+                };
+                match e {
+                    Entry::Occupied(mut o) => {
+                        *o.get_mut() = d;
+                        o.into_mut()
+                    }
+                    Entry::Vacant(v) => v.insert(d),
+                }
+            }
+        }
+    }
+
+    fn find_or_disassemble_memory<'a>(cache: &'a mut HashMap<DisassemblyCacheKey, Disassembly>, debugger: &Debugger, range: Range<usize>, requested_addr: usize, palette: &Palette) -> &'a Disassembly {
+        let indent_width = str_width(&palette.tree_indent.0);
+        let e = cache.entry(DisassemblyCacheKey::Memory(range.start, range.end, requested_addr));
+        match e {
+            Entry::Occupied(o) if o.get().indent_width == indent_width => o.into_mut(),
+            _ => {
+                let d = match debugger.read_code_range(range.clone()) {
+                    Ok((actual_range, code)) => {
+                        let mut prelude = StyledText::default();
+                        styled_writeln!(prelude, palette.default_dim, "memory range: 0x{:x}-0x{:x}", actual_range.start, actual_range.end);
+                        styled_writeln!(prelude, palette.default_dim, "requested address: 0x{:x}", requested_addr);
+                        if let Some(map) = debugger.info.maps.addr_to_map(actual_range.start) {
+                            let path = map.path.as_deref().unwrap_or("[anonymous]");
+                            styled_writeln!(prelude, palette.default_dim, "mapping: 0x{:x}-0x{:x} {}{}{} {}", map.start, map.start + map.len,
+                                if map.perms.contains(MemMapPermissions::READ) {"r"} else {"-"},
+                                if map.perms.contains(MemMapPermissions::WRITE) {"w"} else {"-"},
+                                if map.perms.contains(MemMapPermissions::EXECUTE) {"x"} else {"-"}, path);
+                        }
+                        prelude.close_line();
+                        disassemble_memory(actual_range, &code, prelude, palette)
+                    }
                     Err(e) => Disassembly::new().with_error(e, palette),
                 };
                 match e {
@@ -2080,14 +2319,14 @@ impl DisassemblyWindow {
         // TODO: Print declaration site. Scroll code window to it when selected.
         // TODO: Print number of inlined call sites. Allow setting breakpoint on it.
 
-        Ok(disassemble_function(function_idx, ranges, Some(symbols.as_ref()), None, prelude, palette))
+        Ok(disassemble_function(function_idx, ranges, symbols.as_ref(), prelude, palette))
     }
 
     fn close_error_tab(&mut self) -> Option<usize> {
         if self.tabs.is_empty() {
             return None;
         }
-        if let Some(i) = self.tabs.iter().position(|t| t.locator.is_none()) {
+        if let Some(i) = self.tabs.iter().position(|t| t.locator.is_none() && t.memory_range.is_none()) {
             self.tabs.remove(i);
             if self.tabs_state.selected == i {
                 return None;
@@ -2099,10 +2338,13 @@ impl DisassemblyWindow {
 
     fn evict_cache(&mut self) {
         if self.cache.len().saturating_sub(self.tabs.len()) > 100 {
-            let mut in_use: HashSet<(usize, usize)> = HashSet::new();
+            let mut in_use: HashSet<DisassemblyCacheKey> = HashSet::new();
             for t in &self.tabs {
                 if let Some(x) = t.cached_function_idx.clone() {
-                    in_use.insert(x);
+                    in_use.insert(DisassemblyCacheKey::Function(x.0, x.1));
+                }
+                if let Some(r) = &t.memory_range {
+                    in_use.insert(DisassemblyCacheKey::Memory(r.start, r.end, t.requested_addr));
                 }
             }
             let mut i = 0;
@@ -2135,7 +2377,7 @@ impl DisassemblyWindow {
         }
 
         if let Some(res) = mem::take(&mut d.should_open_document) {
-            match self.open_function(Ok(DisassemblyScrollTarget {binary_id: res.binary_id, function_idx: res.id, static_pseudo_addr: 0, subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true}), debugger) {
+            match self.open_disassembly(Ok(DisassemblyOpenRequest::Function {binary_id: res.binary_id, function_idx: res.id, static_pseudo_addr: 0, subfunction_level: SUBFUNCTION_LEVEL_MAX, cascade: true}), debugger) {
                 Ok(()) => self.tabs[self.tabs_state.selected].ephemeral = false,
                 Err(e) => log!(debugger.log, "{}", e),
             }
@@ -2204,7 +2446,7 @@ impl DisassemblyWindow {
     fn handle_tabs_action(&mut self, action: TabsAction) -> bool {
         if let &TabsAction::Close(idx) = &action {
             if let Some(tab) = self.tabs.get_mut(idx) {
-                if tab.ephemeral && tab.locator.is_some() {
+                if tab.ephemeral && (tab.locator.is_some() || tab.memory_range.is_some()) {
                     tab.ephemeral = false;
                     return true;
                 }
@@ -2213,7 +2455,7 @@ impl DisassemblyWindow {
         self.tabs_state.apply_action(action, &mut self.tabs)
     }
 
-    fn build_tab_content(&mut self, content_root: WidgetIdx, scroll_to_addr: Option<(usize, u16)>, suppress_code_autoscroll: bool, state: &mut UIState, debugger: &mut Debugger, ui: &mut UI) {
+    fn build_tab_content(&mut self, content_root: WidgetIdx, scroll_to: Option<DisassemblyScrollTarget>, suppress_code_autoscroll: bool, state: &mut UIState, debugger: &mut Debugger, ui: &mut UI) {
         let tab = match self.tabs.get_mut(self.tabs_state.selected) {
             None => return,
             Some(x) => x };
@@ -2221,6 +2463,141 @@ impl DisassemblyWindow {
         let start = ui.text.num_lines();
         if let Some(locator) = &tab.locator {
             ui_writeln!(ui, function_name, "{}", locator.demangled_name);
+        }
+
+        if let Some(range) = tab.memory_range.clone() {
+            let requested_addr = tab.requested_addr;
+            let disas = Self::find_or_disassemble_memory(&mut self.cache, debugger, range, requested_addr, &ui.palette);
+            let tab = self.tabs.get_mut(self.tabs_state.selected).unwrap();
+
+            if let Some(DisassemblyScrollTarget::Memory {addr}) = scroll_to {
+                let line = disas.static_pseudo_addr_to_line(addr).0;
+                tab.selected_subfunction_level = 0;
+                tab.area_state.select(line);
+            }
+
+            let rel_addr_digits = (((disas.max_abs_relative_addr as f64 + 1.0).log2() / 4.0).ceil() as usize).max(1);
+            let prefix_width = 2 + 2 + 12+1 + rel_addr_digits+4 + 2 + 1;
+
+            let end = ui.text.num_lines();
+            let (content, visible_y) = with_parent!(ui, content_root, {
+                build_biscrollable_area_with_header(None, start..end, [prefix_width + disas.widest_line, disas.lines.len()], &mut tab.area_state, ui)
+            });
+
+            if let Some(disas_line) = disas.lines.get(tab.area_state.cursor) {
+                let mut cursor_addr = disas_line.static_addr;
+                if cursor_addr == 0 {
+                    cursor_addr = disas.lines.iter().find(|l| l.static_addr != 0).map(|l| l.static_addr).unwrap_or(usize::MAX);
+                }
+
+                for action in ui.check_keys(&[KeyAction::Enter, KeyAction::DeleteRow, KeyAction::EditCondition, KeyAction::StepToCursor]) {
+                    match action {
+                        KeyAction::Enter | KeyAction::DeleteRow | KeyAction::EditCondition | KeyAction::StepToCursor if cursor_addr != usize::MAX => {
+                            let new_breakpoint = InstructionBreakpoint {function: None, addr: cursor_addr, subfunction_level: 0};
+                            if action == KeyAction::StepToCursor {
+                                ui.should_redraw = true;
+                                let r = debugger.step_to_cursor(state.selected_thread, BreakpointOn::Instruction(new_breakpoint));
+                                report_result(state, &r);
+                            } else {
+                                Self::toggle_breakpoint(new_breakpoint, action == KeyAction::DeleteRow, action == KeyAction::EditCondition, tab, &AddrMap::default(), state, debugger, ui);
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+            }
+
+            let mut ip_lines: Vec<(usize, /*selected*/ bool)> = Vec::new();
+            for (idx, frame) in state.stack.frames.iter().enumerate() {
+                let (line, found) = disas.static_pseudo_addr_to_line(frame.pseudo_addr);
+                if found {
+                    ip_lines.push((line, idx == state.selected_frame));
+                }
+            }
+            ip_lines.sort_unstable_by_key(|k| (k.0, !k.1));
+
+            let mut address_breakpoints: Vec<(usize, /*enabled*/ bool, /*location_active*/ bool, /*conditional*/ bool)> = Vec::new();
+            for (_, breakpoint) in debugger.breakpoints.iter() {
+                if let BreakpointOn::Instruction(bp) = &breakpoint.on {
+                    let mut location_active = false;
+                    if breakpoint.active {
+                        let i = debugger.breakpoint_locations.partition_point(|l| l.addr < bp.addr);
+                        if i < debugger.breakpoint_locations.len() && debugger.breakpoint_locations[i].addr == bp.addr {
+                            location_active = debugger.breakpoint_locations[i].active;
+                        }
+                    }
+                    address_breakpoints.push((bp.addr, breakpoint.enabled, location_active, breakpoint.condition.is_some()));
+                }
+            }
+            address_breakpoints.sort_unstable();
+
+            with_parent!(ui, content, {
+                let line_range = visible_y.start.max(0) as usize .. (visible_y.end.max(0) as usize).min(disas.lines.len());
+                let mut main_ip_line: Option<usize> = None;
+                for i in line_range {
+                    let line = &disas.lines[i];
+
+                    if line.kind == DisassemblyLineKind::Instruction {
+                        let addr = line.static_addr;
+                        let ip_idx = ip_lines.partition_point(|x| x.0 < i);
+                        if ip_idx == ip_lines.len() || ip_lines[ip_idx].0 != i {
+                            ui_write!(ui, default, "  ");
+                        } else if ip_lines[ip_idx].1 {
+                            main_ip_line = Some(i);
+                            ui_write!(ui, instruction_pointer, "⮕ ");
+                        } else {
+                            ui_write!(ui, additional_instruction_pointer, "⮕ ");
+                        }
+
+                        let mut marker = "  ";
+                        let mut style = ui.palette.secondary_breakpoint;
+                        let loc_idx = debugger.breakpoint_locations.partition_point(|loc| loc.addr < addr);
+                        if loc_idx < debugger.breakpoint_locations.len() {
+                            let loc = &debugger.breakpoint_locations[loc_idx];
+                            if loc.addr == addr {
+                                for b in &loc.breakpoints {
+                                    match b {
+                                        &BreakpointRef::Id {id, ..} => {
+                                            let conditional = debugger.breakpoints.get(id).condition.is_some();
+                                            (marker, style) = get_breakpoint_icon(/*enabled*/ true, /*active*/ true, /*secondary*/ true, conditional, /*data*/ false, /*stop_on_read*/ false, &ui.palette);
+                                        }
+                                        BreakpointRef::Step(_) => (),
+                                    }
+                                }
+                            }
+                        }
+
+                        let bp_idx = address_breakpoints.partition_point(|(a, _, _, _)| *a < addr);
+                        if bp_idx < address_breakpoints.len() {
+                            let &(a, enabled, location_active, conditional) = &address_breakpoints[bp_idx];
+                            if a == addr {
+                                (marker, style) = get_breakpoint_icon(enabled, location_active, /*secondary*/ false, conditional, /*data*/ false, /*stop_on_read*/ false, &ui.palette);
+                            }
+                        }
+                        styled_write!(ui.text, style, "{}", marker);
+
+                        let addr_style = if line.is_statement {ui.palette.disas_address_statement} else {ui.palette.disas_address_not_statement};
+                        styled_write!(ui.text, addr_style, "{:012x} ", addr);
+                        ui_write!(ui, disas_relative_address, "<{: >+1$x}> ", line.relative_addr, rel_addr_digits + 1);
+                        ui_write!(ui, disas_jump_arrow, " {} ", line.jump_indicator);
+
+                        assert_eq!(ui.text.unclosed_line_width(), prefix_width);
+                    } else if line.kind != DisassemblyLineKind::Intro {
+                        ui_write!(ui, default, "{:1$}", "", prefix_width);
+                    }
+
+                    let l = ui.text.import_lines(&disas.text, i..i+1).start;
+                    let mut w = widget!().identity(&('m', i)).fixed_height(1).fixed_y(i as isize).text(l).fill(' ', ui.palette.default).flags(WidgetFlags::HSCROLL_INDICATOR_RIGHT).highlight_on_hover();
+                    if i == tab.area_state.cursor {
+                        w.style_adjustment.update(ui.palette.selected);
+                    }
+                    if &main_ip_line == &Some(i) {
+                        w.style_adjustment.update(ui.palette.ip_line);
+                    }
+                    ui.add(w);
+                }
+            });
+            return;
         }
 
         let r = self.resolve_function_for_tab(self.tabs_state.selected, debugger);
@@ -2239,7 +2616,7 @@ impl DisassemblyWindow {
 
         let disas = Self::find_or_disassemble_function(&mut self.cache, binary, function_idx, &ui.palette);
 
-        if let Some((static_pseudo_addr, subfunction_level)) = scroll_to_addr {
+        if let Some(DisassemblyScrollTarget::Function {static_pseudo_addr, subfunction_level}) = scroll_to {
             let line = disas.static_pseudo_addr_to_line(static_pseudo_addr).0;
             tab.selected_subfunction_level = subfunction_level;
             tab.area_state.select(line);
@@ -2541,7 +2918,7 @@ impl WindowContent for DisassemblyWindow {
                     if self.go_to_address_bar.text.text.is_empty() {
                         close = true;
                     } else {
-                        match self.find_address(&self.go_to_address_bar.text.text, debugger) {
+                        match self.find_address(&self.go_to_address_bar.text.text, state, debugger) {
                             Ok(target) => {
                                 state.should_scroll_disassembly = Some((Ok(target), /*only_if_on_error_tab*/ false));
                                 close = true;
@@ -2574,18 +2951,18 @@ impl WindowContent for DisassemblyWindow {
         with_parent!(ui, content_root, {ui.multifocus()});
         ui.layout_children(Axis::Y);
 
-        let mut scroll_to_addr: Option<(usize, u16)> = None;
+        let mut scroll_to: Option<DisassemblyScrollTarget> = None;
         let mut suppress_code_autoscroll = false;
-        if let Some((target, only_if_on_error_tab)) = mem::take(&mut state.should_scroll_disassembly) {
+        if let Some((request, only_if_on_error_tab)) = mem::take(&mut state.should_scroll_disassembly) {
             let mut tab_to_restore: Option<usize> = None;
             if only_if_on_error_tab {
                 tab_to_restore = self.close_error_tab();
             }
 
-            if let Ok(target) = &target {
-                suppress_code_autoscroll = !target.cascade;
+            if let Ok(request) = &request {
+                suppress_code_autoscroll = !request.cascade();
                 if tab_to_restore.is_none() {
-                    scroll_to_addr = Some((target.static_pseudo_addr, target.subfunction_level));
+                    scroll_to = Some(request.scroll_target());
                 } else {
                     // (Not ideal that we don't scroll when the tab is not selected, but meh.)
                 }
@@ -2593,7 +2970,7 @@ impl WindowContent for DisassemblyWindow {
                 suppress_code_autoscroll = true;
             }
 
-            if let Err(e) = self.open_function(target, debugger) {
+            if let Err(e) = self.open_disassembly(request, debugger) {
                 log!(debugger.log, "{}", e);
             }
 
@@ -2614,7 +2991,10 @@ impl WindowContent for DisassemblyWindow {
             for tab in &self.tabs {
                 let full_title = match &tab.locator {
                     Some(locator) => locator.demangled_name.clone(),
-                    None => String::new(),
+                    None => match &tab.memory_range {
+                        Some(range) => format!("memory range 0x{:x}-0x{:x}", range.start, range.end),
+                        None => String::new(),
+                    },
                 };
                 tabs.add(Tab {identity: tab.identity, allow_closing: true, short_title: tab.title.clone(), full_title, ephemeral: tab.ephemeral, ..Default::default()}, ui);
             }
@@ -2632,7 +3012,7 @@ impl WindowContent for DisassemblyWindow {
             }
         });
 
-        self.build_tab_content(content_root, scroll_to_addr, suppress_code_autoscroll, state, debugger, ui);
+        self.build_tab_content(content_root, scroll_to, suppress_code_autoscroll, state, debugger, ui);
         
         if self.handle_tabs_action(tabs_action) {
             ui.should_redraw = true;
@@ -2644,11 +3024,13 @@ impl WindowContent for DisassemblyWindow {
             KeyHint::key(KeyAction::Open, "find function"),
             KeyHint::key(KeyAction::GoToLine, "go to address"),
             KeyHint::key(KeyAction::CloseTab, "close/pin tab"),
-            KeyHint::keys(&[KeyAction::PreviousLocation, KeyAction::NextLocation], "select level"),
             KeyHint::keys(&[KeyAction::ReorderRowUp, KeyAction::ReorderRowDown], "reorder tabs"),
             KeyHint::keys(&[KeyAction::Enter, KeyAction::DeleteRow, KeyAction::EditCondition], "breakpoint").if_not_core_dump(),
             KeyHint::key(KeyAction::StepToCursor, "run to cursor").if_not_core_dump(),
         ]);
+        if !self.tabs.get(self.tabs_state.selected).is_some_and(|tab| tab.memory_range.is_some()) {
+            out.push(KeyHint::keys(&[KeyAction::PreviousLocation, KeyAction::NextLocation], "select level"));
+        }
     }
 
     fn save_state(&self, out: &mut Vec<u8>) -> Result<()> {
@@ -2656,27 +3038,42 @@ impl WindowContent for DisassemblyWindow {
             if tab.ephemeral {
                 continue;
             }
-            let locator = match &tab.locator {
-                None => continue,
-                Some(x) => x };
-            out.write_u8(if idx == self.tabs_state.selected {2} else {1})?;
-            locator.save_state(out)?;
-            tab.area_state.save_state(out)?;
-            out.write_u16(tab.selected_subfunction_level)?;
+            if let Some(locator) = &tab.locator {
+                out.write_u8(if idx == self.tabs_state.selected {2} else {1})?;
+                locator.save_state(out)?;
+                tab.area_state.save_state(out)?;
+                out.write_u16(tab.selected_subfunction_level)?;
+            } else if let Some(range) = &tab.memory_range {
+                out.write_u8(if idx == self.tabs_state.selected {4} else {3})?;
+                out.write_usize(range.start)?;
+                out.write_usize(range.end)?;
+                out.write_usize(tab.requested_addr)?;
+                tab.area_state.save_state(out)?;
+                out.write_u16(tab.selected_subfunction_level)?;
+            }
         }
         out.write_u8(0)?;
         Ok(())
     }
     fn load_state(&mut self, inp: &mut &[u8]) -> Result<()> {
         loop {
-            let select_this_tab = match inp.read_u8()? {
-                0 => break,
-                2 => true,
-                _ => false,
-            };
-            let locator = FunctionLocator::load_state(inp)?;
-            let title = Self::make_title(&locator.demangled_name);
-            self.tabs.push(DisassemblyTab {identity: random(), title, locator: Some(locator), error: None, area_state: AreaState::load_state(inp)?, selected_subfunction_level: inp.read_u16()?, ephemeral: false, cached_function_idx: None});
+            let tag = inp.read_u8()?;
+            if tag == 0 {
+                break;
+            }
+            let select_this_tab = tag == 2 || tag == 4;
+            if tag == 1 || tag == 2 {
+                let locator = FunctionLocator::load_state(inp)?;
+                let title = Self::make_title(&locator.demangled_name);
+                self.tabs.push(DisassemblyTab {identity: random(), title, locator: Some(locator), error: None, area_state: AreaState::load_state(inp)?, selected_subfunction_level: inp.read_u16()?, ephemeral: false, cached_function_idx: None, ..Default::default()});
+            } else if tag == 3 || tag == 4 {
+                let start = inp.read_usize()?;
+                let end = inp.read_usize()?;
+                let requested_addr = inp.read_usize()?;
+                self.tabs.push(DisassemblyTab {identity: random(), title: format!("mem:{:x}", requested_addr), memory_range: Some(start..end), requested_addr, error: None, area_state: AreaState::load_state(inp)?, selected_subfunction_level: inp.read_u16()?, ephemeral: false, ..Default::default()});
+            } else {
+                return err!(Format, "unknown disassembly tab tag: {}", tag);
+            }
             if select_this_tab {
                 self.tabs_state.select(self.tabs.len() - 1);
             }
@@ -2687,6 +3084,7 @@ impl WindowContent for DisassemblyWindow {
 
     fn drop_caches(&mut self) {
         self.cache.clear();
+        self.failed_memory_ranges.clear();
         for tab in &mut self.tabs {
             if tab.locator.is_some() {
                 tab.error = None;
@@ -3763,9 +4161,10 @@ impl WindowContent for StackWindow {
             if scroll_source_and_disassembly || rerequest_scroll {
                 state.should_scroll_source = Some((subframe.line.as_ref().map(|line| SourceScrollTarget {path: line.path.clone(), version: Some(line.version.clone()), line: line.line.line(), cascade: false}), !scroll_source_and_disassembly));
                 state.should_scroll_disassembly = Some((match (&frame.binary_id, &state.stack.subframes[frame.subframes.end - 1].function_idx) {
-                    (Err(e), _) => Err(e.clone()),
-                    (_, Err(e)) => Err(e.clone()),
-                    (&Ok(binary_id), &Ok(function_idx)) => Ok(DisassemblyScrollTarget {
+                    (Err(e), _) if e.is_loading() => Err(e.clone()),
+                    (_, Err(e)) if e.is_loading() => Err(e.clone()),
+                    (_, Err(_)) | (Err(_), _) => Ok(DisassemblyOpenRequest::AutoMemory {ip: frame.pseudo_addr, cascade: false}),
+                    (&Ok(binary_id), &Ok(function_idx)) => Ok(DisassemblyOpenRequest::Function {
                         binary_id, function_idx, static_pseudo_addr: frame.pseudo_addr.wrapping_sub(frame.addr_static_to_dynamic),
                         subfunction_level: (frame.subframes.end - state.selected_subframe - 1) as u16, cascade: false}),
                 }, !scroll_source_and_disassembly));
@@ -4360,7 +4759,7 @@ impl CodeWindow {
                 None => closest_idx,
             };
 
-            state.should_scroll_disassembly = Some((Ok(DisassemblyScrollTarget {binary_id: binary.id, function_idx: addrs[idx].0, static_pseudo_addr: addrs[idx].2, subfunction_level: addrs[idx].1, cascade: false}), false));
+            state.should_scroll_disassembly = Some((Ok(DisassemblyOpenRequest::Function {binary_id: binary.id, function_idx: addrs[idx].0, static_pseudo_addr: addrs[idx].2, subfunction_level: addrs[idx].1, cascade: false}), false));
 
             break;
         }
@@ -4992,7 +5391,7 @@ impl WindowContent for BreakpointsWindow {
                                 if let Ok(symbols) = &binary.symbols {
                                     if let Some(function_idx) = symbols.find_nearest_function(&locator.mangled_name, locator.addr) {
                                         let function = &symbols.functions[function_idx];
-                                        state.should_scroll_disassembly = Some((Ok(DisassemblyScrollTarget {
+                                        state.should_scroll_disassembly = Some((Ok(DisassemblyOpenRequest::Function {
                                             binary_id: binary.id, function_idx, static_pseudo_addr: function.addr.0 + offset, subfunction_level: on.subfunction_level, cascade: true}), false));
                                     }
                                 }

--- a/tests/manual/jit_hello.c
+++ b/tests/manual/jit_hello.c
@@ -1,0 +1,59 @@
+#define _GNU_SOURCE
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+typedef void (*jit_fn_t)(void);
+
+int main(void) {
+    const char message[] = "hello world\n";
+
+    // x86-64 Linux:
+    //   mov eax, 1          ; SYS_write
+    //   mov edi, 1          ; stdout
+    //   lea rsi, [rip+disp] ; message
+    //   mov edx, len
+    //   syscall
+    //   ret
+    uint8_t code_template[] = {
+        0xb8, 0x01, 0x00, 0x00, 0x00,
+        0xbf, 0x01, 0x00, 0x00, 0x00,
+        0x48, 0x8d, 0x35, 0x00, 0x00, 0x00, 0x00,
+        0xba, 0x00, 0x00, 0x00, 0x00,
+        0x0f, 0x05,
+        0xc3,
+    };
+
+    const size_t page_size = (size_t)sysconf(_SC_PAGESIZE);
+    void *mem = mmap(NULL, page_size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    const size_t code_size = sizeof(code_template);
+    const size_t message_size = sizeof(message) - 1;
+    uint8_t *code = (uint8_t *)mem;
+    uint8_t *message_dst = code + code_size;
+
+    memcpy(code, code_template, code_size);
+    memcpy(message_dst, message, message_size);
+
+    const size_t lea_disp_offset = 13;
+    const size_t lea_next_ip_offset = 17;
+    int32_t lea_disp = (int32_t)(message_dst - (code + lea_next_ip_offset));
+    memcpy(code + lea_disp_offset, &lea_disp, sizeof(lea_disp));
+
+    const size_t len_offset = 18;
+    uint32_t len = (uint32_t)message_size;
+    memcpy(code + len_offset, &len, sizeof(len));
+
+    mprotect(mem, page_size, PROT_READ | PROT_EXEC);
+
+    printf("jit code address: %p\n", (void *)code);
+    fflush(stdout);
+
+    ((jit_fn_t)code)();
+
+    return 0;
+}


### PR DESCRIPTION
Related:

- fixes #47
- refs #54

This PR makes the disassembly window useful when there is no normal function symbol to open. The existing symbol-backed function view remains preferred and unchanged for ordinary code, but the UI can now fall back to disassembling live process memory for JIT-generated code, anonymous executable mappings, stripped code, and stack frames whose instruction pointer cannot be resolved to a known function.

When the user enters an absolute address with `g`, the debugger first tries the normal function lookup path. If that succeeds, it opens or reuses the regular function disassembly tab with source lines, inline-call structure, symbol names, and function-relative offsets. If no function can be found and symbols are not merely still loading, it reads memory around the requested address and opens a memory disassembly tab instead.

Memory tabs use runtime addresses directly. They show bytes read from the debuggee process, restore original bytes over active software breakpoints, display the containing memory mapping, and support instruction breakpoints and run-to-cursor on raw instruction addresses. They do not show source lines or inline-function structure, because that information belongs to symbol-backed function disassembly.

Automatic stack/IP navigation also falls back to memory disassembly. When the selected stack frame has no usable function information, the disassembly window tries to show a memory tab around the frame instruction pointer instead of leaving the user with only an error tab. Failed automatic reads are remembered to avoid repeatedly probing the same unreadable area until caches are dropped.

Start-address selection is deliberately conservative for automatic IP fallback. The debugger trusts the instruction pointer as a real instruction boundary, then probes candidate decode streams before it. A candidate is accepted only if decoding from that start reaches the instruction pointer exactly as an instruction start, and only if that candidate is unique. If the code cannot prove a unique earlier stream, the memory tab starts at the instruction pointer. This favors showing less context over showing a plausible but wrong x86 decode stream.

Manual address lookup is more pragmatic. If the user-entered address lands inside an instruction, the debugger searches nearby possible starts and chooses the stream that contains the requested address and decodes farthest. If the selected thread's RIP is relevant to that candidate window, it is used as a hard instruction-boundary anchor. If no good candidate is found, the tab starts exactly at the requested address.

Source-level step-into now handles entering code without unwind information more sensibly. This is common for JIT code. When a source-level step-into lands in code where the debugger can no longer compute CFA/unwind state, the step is treated as complete instead of continuing to reason from stale symbolic stack state.

The user-facing help text was updated to describe the new memory-disassembly fallback. Explicit address ranges are still not supported; `g` accepts one raw address and the debugger chooses a useful range around it.

The PR also adds unit coverage for the instruction-start heuristics and a manual JIT test program in C for exercising the new behavior.
